### PR TITLE
Update PDF Chat API route structure for improved organization

### DIFF
--- a/growlimitless.js
+++ b/growlimitless.js
@@ -97,7 +97,7 @@ app.get("/", (req, res) => {
 // API Routes
 app.use("/api/users", userRoutes);
 app.use("/api/bot", botRoutes);
-app.use("/api/pdf-chat", pdfChatRoutes);
+app.use("/api/api-routes/pdf-chat", pdfChatRoutes);
 
 // Error handling middleware (should be last)
 app.use(errorHandler);


### PR DESCRIPTION
- Changed the route for the PDF Chat API from "/api/pdf-chat" to "/api/api-routes/pdf-chat" to enhance clarity and maintain a consistent API structure.
- This update aims to better organize API endpoints and improve overall code maintainability.